### PR TITLE
Add support for GHC 8 by accommodating template-haskell 2.11.*

### DIFF
--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,0 +1,14 @@
+resolver:
+  lts-6.4
+
+packages:
+- '.'
+
+extra-deps:
+  []
+
+flags:
+  {}
+
+extra-package-dbs:
+  []

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,0 +1,16 @@
+resolver:
+  nightly-2016-06-21
+
+packages:
+- '.'
+
+extra-deps:
+  []
+
+flags:
+  {}
+
+extra-package-dbs:
+  []
+
+allow-newer: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,1 @@
-resolver:
-  lts-5.17
-
-packages:
-- '.'
-
-extra-deps:
-  []
-
-flags:
-  {}
-
-extra-package-dbs:
-  []
+stack-7.10.yaml

--- a/test-fixture.cabal
+++ b/test-fixture.cabal
@@ -37,7 +37,7 @@ library
       base >= 4.7 && < 5
     , data-default
     , mtl
-    , template-haskell
+    , template-haskell >= 2.10 && <= 2.11
 
 source-repository head
   type:


### PR DESCRIPTION
Unfortunately, the template-haskell API changes with every GHC release, so we need to do a little bit of conditional compilation to ensure this package works on both GHC 7.10 and GHC 8.0. This adds a constraint in the cabal file to illustrate this dependency, and it also adds a new stack-8.0.yaml for running the code against GHC 8.