### PR TITLE
relax parameters

### DIFF
--- a/src/Control/Monad/TestFixture.hs
+++ b/src/Control/Monad/TestFixture.hs
@@ -243,15 +243,15 @@ instance MonadTrans (TestFixtureT fixture log state) where
   lift = TestFixtureT . lift
 
 -- | The transformer equivalent of 'unTestFixture'.
-unTestFixtureT :: Monad m => TestFixtureT fixture () () m a -> fixture (TestFixtureT fixture () () m) -> m a
+unTestFixtureT :: Monad m => TestFixtureT fixture log state m a -> fixture (TestFixtureT fixture log state m) -> m a
 unTestFixtureT stack env = fmap fst (evalTestFixtureT stack env)
 
 -- | The transformer equivalent of 'logTestFixture'.
-logTestFixtureT :: Monad m => TestFixtureT fixture log () m a -> fixture (TestFixtureT fixture log () m) -> m [log]
+logTestFixtureT :: Monad m => TestFixtureT fixture log state m a -> fixture (TestFixtureT fixture log state m) -> m [log]
 logTestFixtureT stack env = fmap snd (evalTestFixtureT stack env)
 
 -- | The transformer equivalent of 'evalTestFixture'.
-evalTestFixtureT :: Monad m => TestFixtureT fixture log () m a -> fixture (TestFixtureT fixture log () m) -> m (a, [log])
+evalTestFixtureT :: Monad m => TestFixtureT fixture log state m a -> fixture (TestFixtureT fixture log state m) -> m (a, [log])
 evalTestFixtureT stack env = evalRWST (getRWST stack) env ()
 
 -- | The transformer equivalent of 'execTestFixture'.
@@ -268,8 +268,8 @@ runTestFixtureT stack env st = runRWST (getRWST stack) env st
   result. Useful for testing impure functions that return useful values.
 -}
 unTestFixture
-  :: TestFixture fixture () () a         -- ^ the monadic computation to run
-  -> fixture (TestFixture fixture () ()) -- ^ the fixture dictionary to use
+  :: TestFixture fixture log state a         -- ^ the monadic computation to run
+  -> fixture (TestFixture fixture log state) -- ^ the fixture dictionary to use
   -> a                                   -- ^ the computation’s result
 unTestFixture stack env = runIdentity (unTestFixtureT stack env)
 
@@ -279,14 +279,14 @@ unTestFixture stack env = runIdentity (unTestFixtureT stack env)
   testing impure functions called exclusively for side-effects that do not
   depend on complex prior state.
 -}
-logTestFixture :: TestFixture fixture log () a -> fixture (TestFixture fixture log ()) -> [log]
+logTestFixture :: TestFixture fixture log state a -> fixture (TestFixture fixture log state) -> [log]
 logTestFixture stack env = runIdentity (logTestFixtureT stack env)
 
 {-|
   Combines 'unTestFixture' and 'logTestFixture' to return /both/ the
   computation’s result and the written value as a tuple.
 -}
-evalTestFixture :: TestFixture fixture log () a -> fixture (TestFixture fixture log ()) -> (a, [log])
+evalTestFixture :: TestFixture fixture log state a -> fixture (TestFixture fixture log state) -> (a, [log])
 evalTestFixture stack env = runIdentity (evalTestFixtureT stack env)
 
 {-|

--- a/test-fixture.cabal
+++ b/test-fixture.cabal
@@ -1,7 +1,7 @@
 name:
   test-fixture
 version:
-  0.4.0.0
+  0.5.0.0
 synopsis:
   Test monadic side-effects
 description:


### PR DESCRIPTION
Sometimes, you may want to logTestFixture but you have a non-unit state parameter. Relax it!